### PR TITLE
build: Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request includes a new configuration file for Dependabot, a tool that helps to keep your dependencies up-to-date. The file is configured to check for updates in the Maven package ecosystem on a weekly basis.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R6): Added a new configuration file for Dependabot. This file is set up to check for updates in the Maven package ecosystem weekly.