### PR TITLE
build(deps): Bump to narayana-spring-boot-starter 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,12 @@
   <description>Demo with SB and Narayana TM</description>
   <properties>
     <java.version>17</java.version>
-    <snowdrop-narayana.version>2.6.7</snowdrop-narayana.version>
+    <snowdrop-narayana.version>3.1.1</snowdrop-narayana.version>
   </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>me.snowdrop</groupId>
+        <groupId>dev.snowdrop</groupId>
         <artifactId>narayana-spring-boot-starter</artifactId>
         <version>${snowdrop-narayana.version}</version>
       </dependency>
@@ -32,7 +32,7 @@
       <artifactId>spring-boot-starter-activemq</artifactId>
     </dependency>
     <dependency>
-      <groupId>me.snowdrop</groupId>
+      <groupId>dev.snowdrop</groupId>
       <artifactId>narayana-spring-boot-starter</artifactId>
     </dependency>
 


### PR DESCRIPTION
This pull request includes updates to the `pom.xml` file to upgrade the `snowdrop-narayana` version and change the `groupId` for the `narayana-spring-boot-starter` dependency.

Most important changes:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L18-R23): Upgraded the `snowdrop-narayana` version from `2.6.7` to `3.1.1`.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L18-R23): Changed the `groupId` for the `narayana-spring-boot-starter` dependency from `me.snowdrop` to `dev.snowdrop` in two places. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L18-R23) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L35-R35)