### PR TITLE
refactor: Fix application after update to spring-boot 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-activemq</artifactId>
+      <artifactId>spring-boot-starter-artemis</artifactId>
     </dependency>
     <dependency>
       <groupId>dev.snowdrop</groupId>
@@ -41,8 +41,17 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-junit-5</artifactId>
+      <version>${artemis.version}</version>
+      <scope>test</scope>
+    </dependency>
+    
+    
   </dependencies>
-
+      
   <build>
     <plugins>
       <plugin>
@@ -51,5 +60,5 @@
       </plugin>
     </plugins>
   </build>
-
+      
 </project>

--- a/src/main/java/com/bracso/demo/narayana/config/DemoNarayanaConfiguration.java
+++ b/src/main/java/com/bracso/demo/narayana/config/DemoNarayanaConfiguration.java
@@ -3,8 +3,8 @@
  */
 package com.bracso.demo.narayana.config;
 
-import javax.jms.ConnectionFactory;
-import org.apache.activemq.ActiveMQXAConnectionFactory;
+import jakarta.jms.ConnectionFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQXAConnectionFactory;
 import org.springframework.boot.jms.XAConnectionFactoryWrapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,7 +16,7 @@ public class DemoNarayanaConfiguration {
   @Bean
   public ConnectionFactory connectionFactory(XAConnectionFactoryWrapper wrapper) throws Exception {
     ActiveMQXAConnectionFactory activeMQConnectionFactory = new ActiveMQXAConnectionFactory();
-    activeMQConnectionFactory.setBrokerURL("vm://localtestbrokerxa?broker.persistent=false");
+    activeMQConnectionFactory.setBrokerURL("vm://0");
     return wrapper.wrapConnectionFactory(activeMQConnectionFactory);
   }
 

--- a/src/test/java/com/bracso/demo/narayana/ApplicationPoolingTest.java
+++ b/src/test/java/com/bracso/demo/narayana/ApplicationPoolingTest.java
@@ -1,6 +1,9 @@
 package com.bracso.demo.narayana;
 
+import org.apache.activemq.artemis.junit.EmbeddedActiveMQExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jms.core.JmsTemplate;
@@ -10,7 +13,11 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @SpringBootTest
 @ActiveProfiles("pooling")
+@ExtendWith(EmbeddedActiveMQExtension.class)
 class ApplicationPoolingTest {
+
+  @RegisterExtension
+  public EmbeddedActiveMQExtension server = new EmbeddedActiveMQExtension();
 
   @Autowired
   private JmsTemplate jmsTemplate;

--- a/src/test/java/com/bracso/demo/narayana/ApplicationTest.java
+++ b/src/test/java/com/bracso/demo/narayana/ApplicationTest.java
@@ -1,6 +1,8 @@
 package com.bracso.demo.narayana;
 
+import org.apache.activemq.artemis.junit.EmbeddedActiveMQExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jms.core.JmsTemplate;
@@ -8,6 +10,7 @@ import org.springframework.transaction.jta.JtaTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @SpringBootTest
+@ExtendWith(EmbeddedActiveMQExtension.class)
 class ApplicationTest {
 
   @Autowired


### PR DESCRIPTION
This pull request includes changes to the project's dependencies and configuration, replacing the use of `ActiveMQ` with `Artemis` and updating the test environment to reflect these changes. The most significant changes are in the `pom.xml` file where the dependencies are updated, and in the `DemoNarayanaConfiguration.java` and test files where the imports and usage of `ActiveMQ` are replaced with `Artemis`.

Dependency Changes:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L32-R32): Replaced `spring-boot-starter-activemq` with `spring-boot-starter-artemis` and added `artemis-junit-5` for testing. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L32-R32) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R44-R52)

Configuration Changes:

* [`src/main/java/com/bracso/demo/narayana/config/DemoNarayanaConfiguration.java`](diffhunk://#diff-225fa7827991ed11a8c7d5b9bb679a12cf244d2d46aaf05e0f84bbd33ff22fa1L6-R7): Replaced `javax.jms.ConnectionFactory` and `org.apache.activemq.ActiveMQXAConnectionFactory` imports with `jakarta.jms.ConnectionFactory` and `org.apache.activemq.artemis.jms.client.ActiveMQXAConnectionFactory` respectively. Also, updated the `brokerURL` in the `connectionFactory` method. [[1]](diffhunk://#diff-225fa7827991ed11a8c7d5b9bb679a12cf244d2d46aaf05e0f84bbd33ff22fa1L6-R7) [[2]](diffhunk://#diff-225fa7827991ed11a8c7d5b9bb679a12cf244d2d46aaf05e0f84bbd33ff22fa1L19-R19)

Test Environment Changes:

* `src/test/java/com/bracso/demo/narayana/ApplicationPoolingTest.java` and `src/test/java/com/bracso/demo/narayana/ApplicationTest.java`: Added `org.apache.activemq.artemis.junit.EmbeddedActiveMQExtension` import and annotated the classes with `@ExtendWith(EmbeddedActiveMQExtension.class)`. In `ApplicationPoolingTest.java`, also added a `server` instance of `EmbeddedActiveMQExtension`. [[1]](diffhunk://#diff-24887b86a03e5d9ae91ee8cdb46e0ca7c4ff8f85c221971b10acf39260209ac1R3-R6) [[2]](diffhunk://#diff-24887b86a03e5d9ae91ee8cdb46e0ca7c4ff8f85c221971b10acf39260209ac1R16-R21) [[3]](diffhunk://#diff-c438dc71039918b94e452727ac2638b19f7ed1d56b1435affce24020d02c1f89R3-R13)